### PR TITLE
Truncate query parameter in URL

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -107,7 +107,14 @@ fn run(matches: &Matches) -> Result<()> {
         };
         let extension = match download_url.rfind(".") {
             None => typ.as_str(),
-            Some(index) => &download_url[index..],
+            Some(index) => {
+                // truncate query parameters in URL if any
+                if let Some(i) = download_url.rfind("?") {
+                    &download_url[index..i]
+                } else {
+                    &download_url[index..]
+                }
+            },
         };
         let filename = format!("{}{}", song.file_name(&fmt), extension);
         info!("Downloading: [{}/{}]{}]", i + 1, total, filename);


### PR DESCRIPTION
Sometimes the URL for MVs may have query parameter afterwards which screws up the file extension:
```
$ cargo run -- -t mv https://music.163.com/#/song?id=542906780
...
2020-07-25 13:54:12,542 INFO  [main] Downloading: [1/1]大傻DamnShine & GAI周延 & 布瑞吉Bridge - 长河.mp4?wsSecret=61c1d4285520dcd9186adaf36b27aac0&wsTime=1595699652]
2020-07-25 13:54:12,543 ERROR [main] Download file failed: Io(Os { code: 123, kind: Other, message: "The filename, directory name, or volume label syntax is incorrect." })
...
```
This PR fixes that by truncating after `?`.